### PR TITLE
Fix: runcommands now returns array of Strings, related tests changed …

### DIFF
--- a/CI/CI_helpers.py
+++ b/CI/CI_helpers.py
@@ -37,7 +37,7 @@ def run_commands(command_list):
             # if function call was valid
             if result.returncode == None:
                 # append output to list
-                command_output.append(result.communicate()[0])
+                command_output.append(result.communicate()[0].decode())
         except OSError as err:
             command_output.append("Error")
             print(err)

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -6,7 +6,7 @@ from CI.CI_helpers import *
 def test_run_commands_positive():
     commands = ["echo hello", "echo bye"]
     command_output = run_commands(commands)
-    assert command_output == [b'hello\n', b'bye\n']
+    assert command_output == ['hello\n', 'bye\n']
 
 
 def test_run_commands_negative():
@@ -14,7 +14,7 @@ def test_run_commands_negative():
     to list """
     commands = ["ech hello", "echo hello"]
     command_output = run_commands(commands)
-    assert command_output == ["Error", b'hello\n']
+    assert command_output == ["Error", 'hello\n']
 
 
 def test_clone_repo():


### PR DESCRIPTION
…accordingly, close #18 

Now the method returns a list of Strings instead of a list of bytestrings. The two tests connected to the method were changed accordingly.