### PR TITLE
Refactor: Change so that read_configfile returns json, 1 test, close #24

### DIFF
--- a/CI/CI_helpers.py
+++ b/CI/CI_helpers.py
@@ -16,12 +16,8 @@ def clone_repo(ssh_url, target_folder):
 
 def read_configfile(path):
     """Parses a JSON configfile at path and then returns it"""
-
     json_data = open(path)
-    data = json.load(json_data)
-    commands = data["commands"]
-    success_strings = data["success_strings"]
-    return commands, success_strings
+    return json.load(json_data)
 
 
 def run_commands(command_list):

--- a/test/test_helper.py
+++ b/test/test_helper.py
@@ -62,11 +62,11 @@ def test_read_config():
                   }""")
 
     with patch('CI.CI_helpers.open', m):
-        commands, success = read_configfile("foo")
+        config_data = read_configfile("foo")
 
     m.assert_called_once_with("foo")
 
-    assert commands[0] == "pip install -r requirements.txt"
-    assert success[0] == ""
-    assert commands[1] == "python runTests.py"
-    assert success[1] == "TESTS PASSED"
+    assert config_data["commands"][0] == "pip install -r requirements.txt"
+    assert config_data["success_strings"][0] == ""
+    assert config_data["commands"][1] == "python runTests.py"
+    assert config_data["success_strings"][1] == "TESTS PASSED"


### PR DESCRIPTION
Refactoring done so that read_configfile method returns json object instead of two lists. This means that we can, more easily, add and collect more information from config file if we want to in the future. The test for the method was changed accordingly.