### PR TITLE
Feat: Implement route to show build info, 2 tests, close #22

### DIFF
--- a/CI/routes.py
+++ b/CI/routes.py
@@ -1,13 +1,14 @@
+import json
 import os
 import shutil
 
-from flask import request
+from flask import request, render_template, abort
 
 from CI import app
 from CI.CI_helpers import \
     set_commit_state, clone_repo, read_configfile, \
     run_commands, is_successful_command
-from CI.constants import CLONE_FOLDER, CONF
+from CI.constants import CLONE_FOLDER, CONF, HISTORY_FOLDER
 from CI.history_helpers import log_process
 
 
@@ -96,3 +97,21 @@ def github_webhook():
         )
         print(e)
     return ""  # We have to return something
+
+
+@app.route('/history/<owner>/<repo>/<build_id>')
+def build_info(owner, repo, build_id):
+    """This route collects and displays the specified build file"""
+    try:
+        build_file_path = f"{HISTORY_FOLDER}{owner}/{repo}/{build_id}.json"
+        build_data = json.load(open(build_file_path))
+    except FileNotFoundError:
+        abort(404)
+    return render_template("buildinfo.html", context={
+        "owner": owner,
+        "repo": repo,
+        "build_id": build_id,
+        "date": build_data["date"],
+        "hash": build_data["hash"],
+        "results": build_data["results"]
+    })

--- a/CI/templates/buildinfo.html
+++ b/CI/templates/buildinfo.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <title>Build info</title>
+</head>
+<body>
+    <h1>Build info for build #{{build_id}}</h1>
+    <h3>Owner: {{owner}}<br>Repo: {{repo}}<br>Build date: {{ date }}<br>Build hash: {{ hash }}</h3>
+    <ul>
+        {% for result in results %}
+        <li>
+            <b>Command:</b> {{result["command"]}}<br>
+            <b>Status:</b> {{result["status"]}}<br>
+            <b>Output:</b> {{result["output"]}}<br><br>
+        </li>
+        {% endfor %}
+    </ul>
+</body>
+</html>

--- a/test/test_CI_integration_tests.py
+++ b/test/test_CI_integration_tests.py
@@ -73,3 +73,22 @@ def test_github_webhook(client):
     patch_set_state.assert_called_with(repo_name, sha, "success")
 
     fake_log_process.assert_called_once()
+
+
+def test_build_info(client):
+    m = mock_open(
+        read_data='{"date": "170623","hash": "007","results": ['
+                  '{"command": "echo hello","status": 0,"output": "hello\\n"},'
+                  '{"command": "echo bye","status": 0,"output": "bye\\n"}'
+                  ']}'
+    )
+    owner_name = "owner"
+    repo_name = "repo"
+    build_id = "1"
+
+    with patch('CI.routes.open', m):
+        res = client.get('/history/' + owner_name + '/' + repo_name + '/' + build_id)
+
+    m.assert_called_once_with(f"{constants.HISTORY_FOLDER}{owner_name}/{repo_name}/{build_id}.json")
+
+    assert res.status_code == 200


### PR DESCRIPTION
When the route /history/<owner>/<repo>/<build_id> the specified file should be collected and a html containing the info rendered. One positive and one negative test.